### PR TITLE
Rm config

### DIFF
--- a/modelangelo/__init__.py
+++ b/modelangelo/__init__.py
@@ -31,7 +31,7 @@ import pyworkflow
 from pyworkflow.utils import runJob
 from scipion.install.funcs import VOID_TGZ
 
-__version__ = "3.0.3"
+__version__ = "3.0.4"
 _logo = "icon.jpeg"
 _references = ['mabioarxive']
 

--- a/modelangelo/protocols/protocol_model_angelo.py
+++ b/modelangelo/protocols/protocol_model_angelo.py
@@ -86,7 +86,7 @@ class ProtModelAngelo(EMProtocol):
                        label="Choose GPU ID (single one)",
                        help="GPU device to be used")
                        
-        form.addParam('configFile', params.StringParam,
+        form.addParam('configFile', params.FileParam,
                        label="Configuration File",
                        default="",
                        expertLevel=LEVEL_ADVANCED,


### PR DESCRIPTION
Add config file parameter so you can fine tune the program. 

Example of use: model angelo process data in sets of 200 amino-acids, if your input sequence has less than 200 amino-acids the program will fail. In this case create a config file as:

{
  "standardize_mrc_args":
    {
      "target_voxel_size": 1.5,
      "crop_z": 0,
      "bfactor_to_apply": 0,
      "auto_mask": false
    },
  "ca_infer_args":
    {
      "model_checkpoint": "chkpt.torch",
      "bfactor": 0,
      "batch_size": 4,
      "stride": 16,
      "dont_mask_input": true,
      "threshold": 0.05,
      "save_real_coordinates": false,
      "save_cryo_em_grid": false,
      "do_nucleotides": false,
      "save_backbone_trace": false,
      "save_ca_grid": false,
      "crop": 6
    },
  "gnn_infer_args":
    {
      "num_rounds": 3,
      "crop_length": 100,
      "repeat_per_residue": 3,
      "esm_model": "esm1b_t33_650M_UR50S",
      "aggressive_pruning": false,
      "seq_attention_batch_size": 200
    }
}

Note "crop_length" is 100 while the default is 200.