### PR TITLE
Fixing installation with updated modelangelo

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -3,3 +3,4 @@
  - create constants
  - add MODEL_ANGELO_CUDA_LIB
 3.0.1: Installation does not fail but is never complete. So installb modelangelo will git pull all the time.
+3.1.1: Fixed installation to be on pair with the changes introduced by the program developers.

--- a/modelangelo/__init__.py
+++ b/modelangelo/__init__.py
@@ -32,7 +32,7 @@ from scipion.install.funcs import VOID_TGZ
 
 from .constants import *
 
-__version__ = "3.1"
+__version__ = "3.1.1"
 _logo = "logo.jpeg"
 _references = ['jamali2023']
 

--- a/modelangelo/__init__.py
+++ b/modelangelo/__init__.py
@@ -92,7 +92,7 @@ class Plugin(pwem.Plugin):
             installationCmd += 'conda create -y -n modelangelo-' + version + ' python=3.10 && '
             installationCmd += cls.getActivationCmd(version) + ' && '
             installationCmd += 'conda install -y pytorch torchvision torchaudio pytorch-cuda=11.7 -c pytorch -c nvidia && '
-            installationCmd += 'cd model-angelo && pip install -r requirements.txt && '
+            installationCmd += 'cd model-angelo && '
             installationCmd += 'pip install -e . && '
             installationCmd += 'touch ../env-created.txt'
 


### PR DESCRIPTION
Commit https://github.com/3dem/model-angelo/commit/82b38afa78665ffb222a0d91a3e42d5ec5398556 in modelangelo removes the `requirements.txt` file. The plugin installer attempts a `pip install -r requirements.txt` which inevitably fails. As dependencies are now handled by the `setup.py` of modelangelo, the former command is not necessary anymore and should be removed to avoid installation failures.